### PR TITLE
Switched build system to use Ninja

### DIFF
--- a/Game/makefile
+++ b/Game/makefile
@@ -1,5 +1,5 @@
 game:
-	cmake -B build -S . -DCMAKE_TOOLCHAIN_FILE=${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake
+	cmake -B build -S . -DCMAKE_TOOLCHAIN_FILE=${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake -G Ninja
 	cmake --build build
 
 run:

--- a/GameEngine/makefile
+++ b/GameEngine/makefile
@@ -1,5 +1,5 @@
 gameengine:
-	cmake -B build -S . -DCMAKE_TOOLCHAIN_FILE=${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake
+	cmake -B build -S . -DCMAKE_TOOLCHAIN_FILE=${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake -G Ninja
 	cmake --build build
 
 test: gameengine

--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 
 ### Building Locally
 
-In order to build the game engine locally you need to install vcpkg.
+In order to build the game engine locally you need to install vcpkg and the Ninja build system.
 
+To install vcpkg:
 1. Run `git clone https://github.com/microsoft/vcpkg.git` to download the vcpkg project in the directory that you want.
 2. Run `vcpkg/bootstrap-vcpkg.sh` to set up vcpkg
 3. Add VCPKG_ROOT to your environment variables with the directory to vcpkg.
@@ -11,7 +12,11 @@ In order to build the game engine locally you need to install vcpkg.
 
 **NOTE**: If you are using brew on macOS and encountering errors at build-time, try installing vcpkg manually.
 
-After vcpkg is set up run the following commands to download the repository.
+To install Ninja:
+* Apt: `sudo apt install ninja-build`
+* Brew: `brew install ninja`
+
+After vcpkg and Ninja are set up run the following commands to download the repository.
 
 1. `git clone git@github.com:tuvus/GameEngine.git`
 2. `cd GameEngine`


### PR DESCRIPTION
The make build system is actually pretty slow. This PR switches the build to to use ninja instead of make to improve build times by a lot. (Its almost instantaneous for me)

This PR also adds instructions in the README for installing Ninja.