### PR TITLE
Scenenetworking

### DIFF
--- a/Game/include/CardGame.h
+++ b/Game/include/CardGame.h
@@ -36,7 +36,9 @@ class Card_Game : public Application {
     void Update_UI(chrono::milliseconds s) override;
     void set_ui_screen(SCREEN screen);
 
-    ~Card_Game();
+    ~Card_Game() override;
+
+    void Close_Application() override;
 
     EUI_Context curr_ctx = EUI_Context();
     Scene* scene;

--- a/Game/include/Game_Scene.h
+++ b/Game/include/Game_Scene.h
@@ -3,9 +3,11 @@
 #include "Scene.h"
 #include "ui/eui.h"
 
-class Game_Scene : public Scene {
+class Game_Scene : public Scene, Network_Events_Receiver {
+private:
+    Card_Game& card_game;
 public:
-    Game_Scene(Card_Game& card_game) : Scene(card_game) {
+    Game_Scene(Card_Game& card_game) : Scene(card_game), card_game(card_game) {
         EUI_HBox* root = new EUI_HBox();
         root_elem = root;
         root->pos = {0, 0};
@@ -13,13 +15,43 @@ public:
         root->style.vertical_alignment = Alignment::Center;
         root->style.horizontal_alignment = Alignment::Center;
 
-        auto* button = new EUI_Button("Menu", [&card_game] { card_game.set_ui_screen(MENU); });
+        auto* button = new EUI_Button("Menu", [&card_game] {
+            card_game.Close_Network();
+            card_game.set_ui_screen(MENU);
+        });
         button->style.padding = {10, 20, 10, 20};
         root->Add_Child(button);
+        card_game.Get_Network()->connection_events->emplace(static_cast<Network_Events_Receiver*>(this));
+    }
+    ~Game_Scene() override {
+        if (card_game.Get_Network() != nullptr)
+            card_game.Get_Network()->connection_events->erase(static_cast<Network_Events_Receiver*>(this));
     }
 
     void Update_UI(std::chrono::milliseconds, EUI_Context context) override {
         root_elem->Render(context);
     }
     void Update(std::chrono::milliseconds) override {}
+
+    void On_Connected() override {
+    }
+
+    void On_Disconnected() override {
+        card_game.set_ui_screen(MENU);
+        card_game.Close_Network();
+    }
+
+    void On_Server_Start() override {
+    }
+
+    void On_Server_Stop() override {
+        card_game.set_ui_screen(MENU);
+        card_game.Close_Network();
+    }
+
+    void On_Client_Connected(int) override {
+    }
+
+    void On_Client_Disconnected(int) override {
+    }
 };

--- a/Game/include/Lobby_Scene.h
+++ b/Game/include/Lobby_Scene.h
@@ -13,6 +13,7 @@ private:
     int player_count;
   public:
     Lobby_Scene(Card_Game& card_game);
+    ~Lobby_Scene() override;
     void Update_UI(std::chrono::milliseconds, EUI_Context context) override;
     void Update(std::chrono::milliseconds) override;
     void On_Connected() override;

--- a/Game/include/Lobby_Scene.h
+++ b/Game/include/Lobby_Scene.h
@@ -4,7 +4,7 @@
 
 using namespace std;
 
-class Lobby_Scene : public Scene {
+class Lobby_Scene : public Scene, Network_Events_Receiver {
 private:
     EUI_Text* status_text;
     EUI_Button* start_button;
@@ -14,4 +14,11 @@ private:
     Lobby_Scene(Card_Game& card_game);
     void Update_UI(std::chrono::milliseconds, EUI_Context context) override;
     void Update(std::chrono::milliseconds) override;
+    void On_Connected() override;
+    void On_Disconnected() override;
+    void On_Server_Start() override;
+    void On_Server_Stop() override;
+    void On_Client_Connected(int) override;
+    void On_Client_Disconnected(int) override;
+
 };

--- a/Game/include/Lobby_Scene.h
+++ b/Game/include/Lobby_Scene.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "CardGame.h"
 #include "Scene.h"
+#include "networking/Network.h"
 
 using namespace std;
 

--- a/Game/include/Menu_Scene.h
+++ b/Game/include/Menu_Scene.h
@@ -20,6 +20,7 @@ public:
         auto* join_button = new EUI_Button("Join Game", [&card_game] {
             card_game.Connect_To_Server();
             card_game.set_ui_screen(LOBBY);
+            card_game.Get_Network()->Start_Network();
         });
         join_button->style.padding = {10, 20, 10, 20};
         root->Add_Child(join_button);
@@ -27,6 +28,7 @@ public:
         auto* host_button = new EUI_Button("Host Game", [&card_game] {
             card_game.Start_Server();
             card_game.set_ui_screen(LOBBY);
+            card_game.Get_Network()->Start_Network();
         });
         host_button->style.padding = {10, 20, 10, 20};
         root->Add_Child(host_button);

--- a/Game/src/CardGame.cpp
+++ b/Game/src/CardGame.cpp
@@ -3,8 +3,6 @@
 #include "Game_Scene.h"
 #include "Lobby_Scene.h"
 #include "Menu_Scene.h"
-#include "networking/Network.h"
-#include "rpc/client.h"
 
 #include <iostream>
 #include <raylib.h>

--- a/Game/src/CardGame.cpp
+++ b/Game/src/CardGame.cpp
@@ -56,6 +56,7 @@ void Card_Game::Update_UI(chrono::milliseconds deltaTime) {
 
     if (IsKeyPressed(KEY_Q) && IsKeyDown(KEY_LEFT_CONTROL)) {
         Close_Application();
+        return;
     }
 
     curr_ctx.Begin_Frame();
@@ -66,12 +67,23 @@ void Card_Game::Update_UI(chrono::milliseconds deltaTime) {
 
     scene->Update_UI(deltaTime, curr_ctx);
 
-    if (WindowShouldClose())
+    if (WindowShouldClose()) {
         Close_Application();
+        return;
+    }
 
     EndDrawing();
 
     curr_ctx.Render();
 }
 
-Card_Game::~Card_Game() = default;
+Card_Game::~Card_Game() {
+    delete scene;
+    scene = nullptr;
+}
+
+void Card_Game::Close_Application() {
+    delete scene;
+    scene = nullptr;
+    Application::Close_Application();
+}

--- a/Game/src/Lobby_Scene.cpp
+++ b/Game/src/Lobby_Scene.cpp
@@ -37,11 +37,6 @@ Lobby_Scene::Lobby_Scene(Card_Game& card_game)
         return RPC_Manager::VALID;
     });
     card_game.Get_Network()->connection_events->emplace(static_cast<Network_Events_Receiver*>(this));
-    if (card_game.Get_Network()->Get_Network_State() ==Network::Client_Connected) {
-        On_Connected();
-    } else if (card_game.Get_Network()->Get_Network_State() == Network::Server_Running) {
-        On_Server_Start();
-    }
 }
 
 Lobby_Scene::~Lobby_Scene() {
@@ -55,6 +50,8 @@ void Lobby_Scene::Update(std::chrono::milliseconds) {
 }
 
 void Lobby_Scene::On_Connected() {
+    if (player_count == 0)
+        status_text->text = "Connected";
 }
 
 void Lobby_Scene::On_Disconnected() {

--- a/Game/src/Lobby_Scene.cpp
+++ b/Game/src/Lobby_Scene.cpp
@@ -10,10 +10,11 @@ Lobby_Scene::Lobby_Scene(Card_Game& card_game)
     root->style.horizontal_alignment = Alignment::Center;
     root->gap = 20;
     status_text = new EUI_Text("Connecting...");
+    if (card_game.Get_Network()->Is_Server())
+        status_text->text = "Setting up server...";
     root->Add_Child(status_text);
-    start_button = new EUI_Button("Start Game", [this, &card_game]() {
-        card_game.Get_Network()->call_rpc("startgame");
-    });
+    start_button = new EUI_Button(
+        "Start Game", [this, &card_game]() { card_game.Get_Network()->call_rpc("startgame"); });
     start_button->style.padding = {10, 20, 10, 20};
     root->Add_Child(start_button);
     start_button->is_visible = false;
@@ -37,29 +38,39 @@ Lobby_Scene::Lobby_Scene(Card_Game& card_game)
 }
 
 void Lobby_Scene::Update_UI(std::chrono::milliseconds, EUI_Context context) {
-    switch (card_game.Get_Network()->Get_Network_State()) {
-        case Network::Setting_Up:
-            status_text->text = "Setting up server...";
-            break;
-        case Network::Client_Connecting:
-            status_text->text = "Connecting to server...";
-            break;
-        case Network::Server_Running:
-            if (player_count != card_game.Get_Network()->Get_Num_Connected_Clients() + 1)
-                card_game.Get_Network()->call_rpc(
-                    "setplayercount", card_game.Get_Network()->Get_Num_Connected_Clients() + 1);
-            start_button->is_visible = true;
-        case Network::Client_Connected:
-            status_text->text = "Players: " + to_string(player_count);
-            break;
-        case Network::Closing:
-            status_text->text = "Leaving";
-            break;
-        case Network::Closed:
-            status_text->text = "Server closed";
-            break;
-    }
 }
 
 void Lobby_Scene::Update(std::chrono::milliseconds) {
+}
+
+void Lobby_Scene::On_Connected() {
+    player_count = 0;
+    status_text->text = "Connected";
+}
+
+void Lobby_Scene::On_Disconnected() {
+    card_game.set_ui_screen(MENU);
+}
+
+void Lobby_Scene::On_Server_Start() {
+    player_count = 1;
+    status_text->text = "Connected";
+}
+
+void Lobby_Scene::On_Server_Stop() {
+    card_game.set_ui_screen(MENU);
+}
+
+void Lobby_Scene::On_Client_Connected(int) {
+    player_count++;
+    card_game.Get_Network()->call_rpc("setplayercount", player_count);
+    if (player_count > 1)
+        start_button->is_visible = true;
+}
+
+void Lobby_Scene::On_Client_Disconnected(int) {
+    player_count--;
+    card_game.Get_Network()->call_rpc("setplayercount", player_count);
+    if (player_count <= 1)
+        start_button->is_visible = true;
 }

--- a/Game/src/main.cpp
+++ b/Game/src/main.cpp
@@ -3,7 +3,6 @@
 #include "Application.h"
 #include "ApplicationFactory.h"
 #include "CardGame.h"
-#include <raylib.h>
 
 class CardGameFactory : public ApplicationFactory {
   public:

--- a/GameEngine/include/GameEngine/Application.h
+++ b/GameEngine/include/GameEngine/Application.h
@@ -48,7 +48,7 @@ protected:
     string Get_Name();
     shared_ptr<Network> Get_Network();
 
-    void Close_Application();
+    virtual void Close_Application();
     void Close_Network();
 };
 

--- a/GameEngine/include/GameEngine/Application.h
+++ b/GameEngine/include/GameEngine/Application.h
@@ -1,10 +1,9 @@
 #pragma once
 
-#include "networking//Network.h"
+#include "networking/Network.h"
 #include "ui/eui.h"
 
 #include <chrono>
-#include <cstdint>
 
 using namespace std;
 

--- a/GameEngine/include/GameEngine/Scene.h
+++ b/GameEngine/include/GameEngine/Scene.h
@@ -9,6 +9,7 @@ class Scene {
 
   public:
     Scene(Application& app) : application(app) {}
+    virtual ~Scene() { delete root_elem; }
     virtual void Update_UI(std::chrono::milliseconds, EUI_Context) = 0;
     virtual void Update(std::chrono::milliseconds) = 0;
     EUI_Element* Get_Root() { return root_elem; }

--- a/GameEngine/include/GameEngine/networking/Network.h
+++ b/GameEngine/include/GameEngine/networking/Network.h
@@ -43,15 +43,6 @@ public:
     virtual void On_Client_Disconnected(int) = 0;
 };
 
-class Network_Events_Receiver_Hash_Function {
-public:
-    // id is returned as hash function
-    size_t operator()(const Network_Events_Receiver* e) const
-    {
-        return reinterpret_cast<size_t>(e);
-    }
-};
-
 class Network
 {
 public:
@@ -110,7 +101,7 @@ public:
     void Send_Message_To_Server(const Rpc_Message& rpc_message);
 
     // Holds aset of subscribers to the networking events that can occur
-    std::unique_ptr<std::unordered_set<Network_Events_Receiver*, Network_Events_Receiver_Hash_Function>> connection_events;
+    std::unique_ptr<std::unordered_set<Network_Events_Receiver*>> connection_events;
 
     /**
      * Calls the function on the server.

--- a/GameEngine/include/GameEngine/networking/Network.h
+++ b/GameEngine/include/GameEngine/networking/Network.h
@@ -28,20 +28,19 @@ struct Rpc_Message
 };
 
 class Network_Events_Receiver {
-private:
-
-    // const size_t i2d = 1;
-    // static size_t next_id;
-
 public:
-    // Network_Events_Receiver() : id(next_id++) {}
+    // Called on the client when the client is connected
     virtual void On_Connected() = 0;
+    // Called on the client when the client is disconnected (not on the host)
     virtual void On_Disconnected() = 0;
+    // Called on the server when the server is started
     virtual void On_Server_Start() = 0;
+    // Called on the server when the server is stopped
     virtual void On_Server_Stop() = 0;
+    // Called on the server when a client is connected
     virtual void On_Client_Connected(int) = 0;
+    // Called on the server when a client is disconnected
     virtual void On_Client_Disconnected(int) = 0;
-    // const size_t id;
 };
 
 class Network_Events_Receiver_Hash_Function {

--- a/GameEngine/include/GameEngine/networking/Network.h
+++ b/GameEngine/include/GameEngine/networking/Network.h
@@ -7,7 +7,6 @@
 #include <steam/isteamnetworkingsockets.h>
 
 #include "Rpc_Manager.h"
-#include "Scene.h"
 
 struct Rpc_Message
 {
@@ -29,13 +28,30 @@ struct Rpc_Message
 };
 
 class Network_Events_Receiver {
+private:
+
+    const size_t i2d = 1;
+    static size_t next_id;
+
 public:
+    Network_Events_Receiver() : id(next_id++) {}
+    virtual ~Network_Events_Receiver() = default;
     virtual void On_Connected() = 0;
     virtual void On_Disconnected() = 0;
     virtual void On_Server_Start() = 0;
     virtual void On_Server_Stop() = 0;
     virtual void On_Client_Connected(int) = 0;
     virtual void On_Client_Disconnected(int) = 0;
+    const size_t id;
+};
+
+class Network_Events_Receiver_Hash_Function {
+public:
+    // id is returned as hash function
+    size_t operator()(const Network_Events_Receiver& e) const
+    {
+        return e.id;
+    }
 };
 
 class Network
@@ -94,7 +110,7 @@ public:
     void Send_Message_To_Clients(const Rpc_Message& rpc_message);
     void Send_Message_To_Server(const Rpc_Message& rpc_message);
 
-    std::unique_ptr<std::unordered_set<Network_Events_Receiver>> connection_events;
+    std::unique_ptr<std::unordered_set<Network_Events_Receiver, Network_Events_Receiver_Hash_Function>> connection_events;
 
     /**
      * Calls the function on the server.

--- a/GameEngine/include/GameEngine/networking/Network.h
+++ b/GameEngine/include/GameEngine/networking/Network.h
@@ -100,6 +100,7 @@ public:
     void On_Connection_Status_Changed(SteamNetConnectionStatusChangedCallback_t* new_status);
     Network(bool server, std::function<void()> close_network_function);
     ~Network();
+    void Start_Network();
     void Network_Update();
     Network_State Get_Network_State();
     int Get_Num_Connected_Clients() const;

--- a/GameEngine/include/GameEngine/networking/Network.h
+++ b/GameEngine/include/GameEngine/networking/Network.h
@@ -30,27 +30,26 @@ struct Rpc_Message
 class Network_Events_Receiver {
 private:
 
-    const size_t i2d = 1;
-    static size_t next_id;
+    // const size_t i2d = 1;
+    // static size_t next_id;
 
 public:
-    Network_Events_Receiver() : id(next_id++) {}
-    virtual ~Network_Events_Receiver() = default;
+    // Network_Events_Receiver() : id(next_id++) {}
     virtual void On_Connected() = 0;
     virtual void On_Disconnected() = 0;
     virtual void On_Server_Start() = 0;
     virtual void On_Server_Stop() = 0;
     virtual void On_Client_Connected(int) = 0;
     virtual void On_Client_Disconnected(int) = 0;
-    const size_t id;
+    // const size_t id;
 };
 
 class Network_Events_Receiver_Hash_Function {
 public:
     // id is returned as hash function
-    size_t operator()(const Network_Events_Receiver& e) const
+    size_t operator()(const Network_Events_Receiver* e) const
     {
-        return e.id;
+        return reinterpret_cast<size_t>(e);
     }
 };
 
@@ -110,7 +109,7 @@ public:
     void Send_Message_To_Clients(const Rpc_Message& rpc_message);
     void Send_Message_To_Server(const Rpc_Message& rpc_message);
 
-    std::unique_ptr<std::unordered_set<Network_Events_Receiver, Network_Events_Receiver_Hash_Function>> connection_events;
+    std::unique_ptr<std::unordered_set<Network_Events_Receiver*, Network_Events_Receiver_Hash_Function>> connection_events;
 
     /**
      * Calls the function on the server.

--- a/GameEngine/include/GameEngine/networking/Network.h
+++ b/GameEngine/include/GameEngine/networking/Network.h
@@ -109,6 +109,7 @@ public:
     void Send_Message_To_Clients(const Rpc_Message& rpc_message);
     void Send_Message_To_Server(const Rpc_Message& rpc_message);
 
+    // Holds aset of subscribers to the networking events that can occur
     std::unique_ptr<std::unordered_set<Network_Events_Receiver*, Network_Events_Receiver_Hash_Function>> connection_events;
 
     /**

--- a/GameEngine/include/GameEngine/networking/Network.h
+++ b/GameEngine/include/GameEngine/networking/Network.h
@@ -5,9 +5,9 @@
 #include <string>
 #include <utility>
 #include <steam/isteamnetworkingsockets.h>
-#include <string>
 
 #include "Rpc_Manager.h"
+#include "Scene.h"
 
 struct Rpc_Message
 {
@@ -26,6 +26,16 @@ struct Rpc_Message
 
     // Tells msgpack how to serialize Rpc_Message
     MSGPACK_DEFINE(rpc_call)
+};
+
+class Network_Events_Receiver {
+public:
+    virtual void On_Connected() = 0;
+    virtual void On_Disconnected() = 0;
+    virtual void On_Server_Start() = 0;
+    virtual void On_Server_Stop() = 0;
+    virtual void On_Client_Connected(int) = 0;
+    virtual void On_Client_Disconnected(int) = 0;
 };
 
 class Network
@@ -83,6 +93,8 @@ public:
     void Send_Message_To_Client(HSteamNetConnection connection, const Rpc_Message& rpc_message);
     void Send_Message_To_Clients(const Rpc_Message& rpc_message);
     void Send_Message_To_Server(const Rpc_Message& rpc_message);
+
+    std::unique_ptr<std::unordered_set<Network_Events_Receiver>> connection_events;
 
     /**
      * Calls the function on the server.

--- a/GameEngine/include/GameEngine/ui/eui.h
+++ b/GameEngine/include/GameEngine/ui/eui.h
@@ -102,7 +102,7 @@ class EUI_Context {
 
 class EUI_Element {
   public:
-    virtual ~EUI_Element() = default;
+    virtual ~EUI_Element() { is_deleted = true; }
 
     std::string id;
 
@@ -115,6 +115,7 @@ class EUI_Element {
     bool is_hovered = false;
     bool is_focused = false;
     bool is_active = false;
+    bool is_deleted = false;
 
     EUI_Style style;
 

--- a/GameEngine/src/networking/Network.cpp
+++ b/GameEngine/src/networking/Network.cpp
@@ -16,7 +16,7 @@ Network::Network(bool server, std::function<void()> close_network_function)
 {
     network_instance = this;
     state = Setting_Up;
-    connection_events = make_unique<std::unordered_set<Network_Events_Receiver>>();
+    connection_events = make_unique<std::unordered_set<Network_Events_Receiver, Network_Events_Receiver_Hash_Function>>();
 
     SteamDatagramErrMsg err_msg;
     if (!GameNetworkingSockets_Init(nullptr, err_msg))
@@ -380,3 +380,4 @@ void Debug_Output(ESteamNetworkingSocketsDebugOutputType error_type, const char*
 }
 
 Network* Network::network_instance = nullptr;
+size_t Network_Events_Receiver::next_id = 0;

--- a/GameEngine/src/networking/Network.cpp
+++ b/GameEngine/src/networking/Network.cpp
@@ -16,7 +16,7 @@ Network::Network(bool server, std::function<void()> close_network_function)
 {
     network_instance = this;
     state = Setting_Up;
-    connection_events = make_unique<std::unordered_set<Network_Events_Receiver*, Network_Events_Receiver_Hash_Function>>();
+    connection_events = make_unique<std::unordered_set<Network_Events_Receiver*>>();
     rpc_manager = make_unique<RPC_Manager>();
 }
 

--- a/GameEngine/src/networking/Network.cpp
+++ b/GameEngine/src/networking/Network.cpp
@@ -386,4 +386,3 @@ void Debug_Output(ESteamNetworkingSocketsDebugOutputType error_type, const char*
 }
 
 Network* Network::network_instance = nullptr;
-// size_t Network_Events_Receiver::next_id = 0;

--- a/GameEngine/src/ui/container.cpp
+++ b/GameEngine/src/ui/container.cpp
@@ -12,9 +12,11 @@ void EUI_Container::Handle_Input(EUI_Context& ctx) {
     if (!is_visible)
         return;
 
-    for (EUI_Element* child : children) {
-        if (child->is_visible)
-            child->Handle_Input(ctx);
+    // We have to make sure that we can handle concurrent modification
+    // Changing scenes for example will delete all UI elements
+    for (int i = 0; i < children.size(); ++i) {
+        if (children[i]->is_visible)
+            children[i]->Handle_Input(ctx);
     }
 }
 

--- a/GameEngine/src/ui/container.cpp
+++ b/GameEngine/src/ui/container.cpp
@@ -9,14 +9,14 @@ void EUI_Container::Add_Child(EUI_Element* child) {
 }
 
 void EUI_Container::Handle_Input(EUI_Context& ctx) {
-    if (!is_visible)
+    if (!is_visible || is_deleted)
         return;
 
-    // We have to make sure that we can handle concurrent modification
-    // Changing scenes for example will delete all UI elements
-    for (int i = 0; i < children.size(); ++i) {
-        if (children[i]->is_visible)
-            children[i]->Handle_Input(ctx);
+    for (EUI_Element* child : children) {
+        if (child->is_visible) {
+            child->Handle_Input(ctx);
+            if (is_deleted) return;
+        }
     }
 }
 


### PR DESCRIPTION
This PR allows scenes to explicitly listen for major server and client networking events. The host and clients shouldn't run into any errors when disconnecting in the scenes. Scenes inherit from Network_Events_Receiver to subscribe to network.connection_events which will allow them to receive notifications from the network.

I also think my formatter changed its style once again.